### PR TITLE
added whatshap haplotagging

### DIFF
--- a/intermediate/whatshap_haplotag_script.sh
+++ b/intermediate/whatshap_haplotag_script.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+source /home/tobias-lab/miniconda3/bin/activate whatshap-env
+OUTPUT_ALIGNMENT="$1"
+REFERENCE="$2"
+PHASED_VCF="$3"
+INPUT_ALIGNMENT="$4"
+
+whatshap haplotag --ignore-read-groups \
+	-o $OUTPUT_ALIGNMENT  \
+	--reference $REFERENCE \
+	$PHASED_VCF \
+	$INPUT_ALIGNMENT

--- a/sylvies_devider_pipeline.sh
+++ b/sylvies_devider_pipeline.sh
@@ -91,3 +91,12 @@ ${OUTPUT_DIR}/alignments/${GENE_NAME}_alignment_sorted.bam \
 ${OUTPUT_DIR}/devider_output \
 ${MINIMUM_ABUNDANCE} \
 ${THREADS}
+
+
+#whatshap
+mkdir ${OUTPUT_DIR}/whatshap_output
+${script_path}/intermediate/whatshap_haplotag_script.sh \
+	${OUTPUT_DIR}/whatshap_output/${GENE_NAME}_alignment_haplotagged.bam \
+	${INPUT_DIR}/${REFERENCE_FASTA} \
+	${OUTPUT_DIR}/clair3_output/phased_merge_output.vcf.gz \
+	${OUTPUT_DIR}/alignments/${GENE_NAME}_alignment_sorted.bam


### PR DESCRIPTION
now the devider pipeline also runs whatshap to haplotag the .bam alignment using phased vcf from clair3.
this offers an alternative to the devider output.